### PR TITLE
A few remaining Python 3 issues

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -12,7 +12,7 @@ import threading
 
 class Storage(object):
     def __init__(self, **kwds):
-        for k, v in kwds.iteritems():
+        for k, v in kwds.items():
             setattr(self, k, v)
 
 class WebUI(web.RequestHandler):

--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ MAX_ITEM_SIZE_GB = 10
 def is_alnum(x): return x.isalnum()
 def is_integer(x): return type(x) == int
 def is_name(x): return re.match(r'[-_a-zA-Z0-9]+$', x)
-def is_boolean(x): return isinstance(x, (bool, int, long))
+def is_boolean(x): return isinstance(x, (bool, int))
 
 class DrainConfig(object):
     def __init__(self, fname):
@@ -29,7 +29,7 @@ class DrainConfig(object):
                 return yaml.safe_load(f.read())
         except OSError:
             print("Failed to open %s" % fname, file=sys.stderr)
-        except (yaml.YAMLError, exc):
+        except yaml.YAMLError as exc:
             print("Error parsing config:", exc, file=sys.stderr)
             sys.exit(1)
 
@@ -37,7 +37,7 @@ class DrainConfig(object):
         v = self.get_param(name)
         if not vf(v):
             raise ValueError('%s %s: %s' % (name, msg, v))
- 
+
     def check_integer(self, name):
         self.__check(name, is_integer, 'must be an integer')
 
@@ -261,7 +261,7 @@ class DrainConfig(object):
         """returns iterator on parameters defined in YAML.
         (does not include synthetic config parameters)
         """
-        return self.cfg.iteritems()
+        return self.cfg.items()
 
     def pprint(self, param=None, format=None, out=sys.stdout):
         if param is None:

--- a/dtmon.py
+++ b/dtmon.py
@@ -27,9 +27,20 @@ try:
 except:
     pwd = None
 
+def cmp(x, y):  # https://portingguide.readthedocs.io
+    """
+    Replacement for built-in function cmp that was removed in Python 3
+
+    Compare the two objects x and y and return an integer according to
+    the outcome. The return value is negative if x < y, zero if x == y
+    and strictly positive if x > y.
+    """
+    return (x > y) - (x < y)
+
+
 class Storage(object):
     def __init__(self, **kwds):
-        for k, v in kwds.iteritems():
+        for k, v in kwds.items():
             setattr(self, k, v)
 
 def readfile(fn):


### PR DESCRIPTION
Flake8 output: https://github.com/cclauss/draintasker/actions

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.
